### PR TITLE
remove incorrect and unhelpful comment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,6 @@ interface Instruction {
 	definitions: Record<string, TAnySchema>
 }
 
-// equivalent to /["\n\r\t\b\f\v]/
 const findEscapeSequence = /["\b\t\n\v\f\r\/]/
 
 const SANITIZE = {


### PR DESCRIPTION
The comment didn't mention the `/` character which is matched by the actual regexp. Also, it doesn't seem helpful to just list the characters in a character class in a different order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated inline comment related to escape sequence handling to keep comments accurate and reduce confusion. This change does not affect functionality, behavior, UI, performance, or configuration. No user action is required; there are no API or compatibility changes. All existing features continue to work exactly as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->